### PR TITLE
teward refactor, round 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 conf/settings.cfg
+
+# PyCharm IDE
+.idea/

--- a/README.mkd
+++ b/README.mkd
@@ -25,6 +25,7 @@ conf/settings.cfg::
     [bottle]
     cache_host=localhost
     cache_db=0
+    host=0.0.0.0
     port=80
     root_path=.
     url=http://p.ngx.cc/

--- a/app.py
+++ b/app.py
@@ -336,5 +336,5 @@ def check_captcha(answer, addr=None):
 
 if __name__ == '__main__':
     bottle.run(
-        host='0.0.0.0',
+        host=conf.getint('bottle', 'host'),
         port=conf.getint('bottle', 'port'))

--- a/app.py
+++ b/app.py
@@ -315,7 +315,7 @@ def str2int(v):
     """
     Convert string to boolean to integer
     """
-    return int(v.lower() in ('yes', 'true', 't', 'y', '1', 'on'))
+    return int(str2bool(v))
 
 
 def check_captcha(answer, addr=None):

--- a/app.py
+++ b/app.py
@@ -10,14 +10,11 @@ from pygments.formatters import HtmlFormatter
 import binascii
 import ConfigParser
 import difflib
-import hashlib
 import json
 import os
-import random
 import re
 import redis
 import requests
-import string
 import socket
 
 from furl import furl
@@ -43,6 +40,7 @@ app = application = bottle.Bottle()
 cache = redis.Redis(host=conf.get('bottle', 'cache_host'), db=int(conf.get('bottle', 'cache_db')))
 
 
+# noinspection PyUnresolvedReferences
 @app.route('/static/<filename:path>')
 def static(filename):
     """
@@ -113,7 +111,8 @@ def submit_paste():
     """
     Put a new paste into the database
     """
-    r = re.compile('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,.\/a-zA-Z0-9]{1,48}$')
+    # noinspection PyUnusedLocal
+    r = re.compile('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$')
     paste = {
         'code': bottle.request.POST.get('code', ''),
         'name': bottle.request.POST.get('name', '').strip(),
@@ -130,13 +129,13 @@ def submit_paste():
         if paste[k] == '':
             return bottle.jinja2_template('error.html', code=200,
                                           message='All fields need to be filled out. ER:577')
-    if not re.match('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,.\/a-zA-Z0-9]{1,48}$', paste['name']):
+    if not re.match('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$', paste['name']):
         return bottle.jinja2_template('error.html', code=200,
                                       message='Invalid input detected. ERR:925')
 
         # Basic spam checks
-        return bottle.jinja2_template('error.html', code=200,
-                                      message='Your post triggered our spam filters! ERR:615')
+        # return bottle.jinja2_template('error.html', code=200,
+        #                               message='Your post triggered our spam filters! ERR:615')
     if bottle.request.POST.get('phone', '').strip() != '':
         return bottle.jinja2_template('error.html', code=200,
                                       message='Your post triggered our spam filters! ERR:228')
@@ -177,6 +176,7 @@ def submit_paste():
     bottle.redirect('/' + paste_id)
 
 
+# noinspection PyBroadException
 @app.route('/<paste_id>')
 def view_paste(paste_id):
     """
@@ -254,6 +254,7 @@ def delete_spam(paste_id):
         return 'Error removing paste'
 
 
+# noinspection PyBroadException
 def send_irc(paste, paste_id):
     """
     Send notification to channels

--- a/app.py
+++ b/app.py
@@ -111,7 +111,6 @@ def submit_paste():
     """
     Put a new paste into the database
     """
-    # noinspection PyUnusedLocal
     r = re.compile('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$')
     paste = {
         'code': bottle.request.POST.get('code', ''),
@@ -129,7 +128,7 @@ def submit_paste():
         if paste[k] == '':
             return bottle.jinja2_template('error.html', code=200,
                                           message='All fields need to be filled out. ER:577')
-    if not re.match('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$', paste['name']):
+    if not r.match(paste['name']):
         return bottle.jinja2_template('error.html', code=200,
                                       message='Invalid input detected. ERR:925')
 


### PR DESCRIPTION
Several different commit sets in here, so I'll give some details.

(1) Update `.gitignore`.  Since I use PyCharm IDE, let's ignore its `.idea` folder which contains IDE-environment-specific cruft we don't want in the repo.

(2) This needed some work to be in compliance with PEP8 style guides, so I did that.

(3) We did some code cleanup.  There were unused modules, so we don't import them anymore.  I had to add some IDE suppressions here, for some stupid warnings we're disregarding.  And, we had unnecessary character escapes in the Regexes, which this removes.

(4) We don't need to hardcode the 'host' to bind to in the app itself.  Let's give it its own configuration variable, yes?  (Updates README accordingly)

(5) We already have `str2bool`, so let's utilize it in `str2int`, rather than repeating code.

(6)(r = re.compile('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$')) serves no useful purpose (line 114 after the above referenced commits) because we don't refer to `r` anywhere, though it's got a compiled regex.  So, let's pull out (if not re.match('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$', paste['name']):) from `app.py` on Line 132 and actually make use of `r`: `if not r.match(paste['name']):`  Testing this, it seems to work (from Python 2 console):

```
>>> import re
>>> r = re.compile('^[- !$%^&*()_+|~=`{}\[\]:";\'<>?,./a-zA-Z0-9]{1,48}$')
>>> if r.match('Hail Hydra'):
...   print True
... else:
...   print False
... 
True
```